### PR TITLE
#8 Update hp stats on pepemon card after round

### DIFF
--- a/Assets/Scripts/Controllers/GameController.cs
+++ b/Assets/Scripts/Controllers/GameController.cs
@@ -138,6 +138,8 @@ public class GameController : MonoBehaviour
                     _player1.CurrentHand.RemoveAllOffenseCards();
 
                     _uiController.UpdateUI();
+                    player1Controller.UpdateCard(_player1);
+                    player2Controller.UpdateCard(_player2);
 
                     if (_player2.CurrentHP <= 0) Winner(_player1);
                 }
@@ -154,6 +156,8 @@ public class GameController : MonoBehaviour
                     _player2.CurrentHand.RemoveAllOffenseCards();
 
                     _uiController.UpdateUI();
+                    player1Controller.UpdateCard(_player1);
+                    player2Controller.UpdateCard(_player2);
 
                     if (_player1.CurrentHP <= 0) Winner(_player2);
                 }
@@ -199,6 +203,8 @@ public class GameController : MonoBehaviour
 
             _uiController.FlipCards(1);
             _uiController.UpdateUI();
+            player1Controller.UpdateCard(_player1);
+            player2Controller.UpdateCard(_player2);
 
             if (_player2.CurrentHP <= 0) Winner(_player1);
         }
@@ -210,6 +216,8 @@ public class GameController : MonoBehaviour
 
             _uiController.FlipCards(2);
             _uiController.UpdateUI();
+            player1Controller.UpdateCard(_player1);
+            player2Controller.UpdateCard(_player2);
 
             if (_player1.CurrentHP <= 0) Winner(_player2);
         }

--- a/Assets/Scripts/Controllers/PepemonCardController.cs
+++ b/Assets/Scripts/Controllers/PepemonCardController.cs
@@ -59,4 +59,9 @@ public class PepemonCardController : MonoBehaviour
         _cardContentBackdrop.sprite = pepemonData.CardContentBackdrop;
         _cardContent.sprite = pepemonData.CardContent;
     }
+
+    public void UpdateCard(Player player)
+    {
+        _hpText.text = player.CurrentHP.ToString();
+    }
 }


### PR DESCRIPTION
Resolves #8

## Acceptance criteria
* HP as displayed in UI are the same as the HP displayed in the Pepemon card after each round

## Screenshot of issue

![afbeelding](https://user-images.githubusercontent.com/8208970/165854890-edcb6775-6191-471d-a8bb-db1b37869ddb.png)
