### PR TITLE
Replace splash video without audio to one with audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ crashlytics-build.properties
 .vscode/settings.json
 
 .vsconfig
+
+.DS_Store

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -13435,6 +13435,7 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+  onVideoFinishedDelay: 2
 --- !u!1 &1580972200
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/StartScreen.unity
+++ b/Assets/Scenes/StartScreen.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3731193, g: 0.38073996, b: 0.35872698, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311915, g: 0.3807396, b: 0.35872662, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -13339,13 +13339,13 @@ VideoPlayer:
   m_AspectRatio: 1
   m_DataSource: 1
   m_PlaybackSpeed: 1
-  m_AudioOutputMode: 0
+  m_AudioOutputMode: 2
   m_TargetAudioSources:
-  - {fileID: 0}
+  - {fileID: 721296644}
   m_DirectAudioVolumes:
   - 1
   m_Url: 
-  m_EnabledAudioTracks: 00
+  m_EnabledAudioTracks: 01
   m_DirectAudioMutes: 00
   m_ControlledAudioTrackCount: 1
   m_PlayOnAwake: 0

--- a/Assets/Scripts/Effects/StreamingVideoLoader.cs
+++ b/Assets/Scripts/Effects/StreamingVideoLoader.cs
@@ -12,6 +12,7 @@ public class StreamingVideoLoader : MonoBehaviour
     public bool isStreamingAsset;
     public UnityEvent onVideoStarted;
     public UnityEvent onVideoFinished;
+    public float onVideoFinishedDelay = 2f;
 
     private bool finished = false;
 
@@ -46,10 +47,12 @@ public class StreamingVideoLoader : MonoBehaviour
         OnVideoFinished(source);
     }
 
-    private void OnVideoFinished(VideoPlayer _)
+    private async void OnVideoFinished(VideoPlayer _)
     {
         if (!finished)
         {
+            // Wait a bit before calling the event
+            await Task.Delay((int)(onVideoFinishedDelay * 1000));
             onVideoFinished?.Invoke();
             finished = true;
         }

--- a/Assets/Scripts/Effects/StreamingVideoLoader.cs
+++ b/Assets/Scripts/Effects/StreamingVideoLoader.cs
@@ -51,10 +51,10 @@ public class StreamingVideoLoader : MonoBehaviour
     {
         if (!finished)
         {
+            finished = true;
             // Wait a bit before calling the event
             await Task.Delay((int)(onVideoFinishedDelay * 1000));
             onVideoFinished?.Invoke();
-            finished = true;
         }
     }
 

--- a/Assets/StreamingAssets/splash_video.mp4.meta
+++ b/Assets/StreamingAssets/splash_video.mp4.meta
@@ -1,18 +1,7 @@
 fileFormatVersion: 2
 guid: 4b60546f62aebba4f8cda2ed29012ceb
-VideoClipImporter:
+DefaultImporter:
   externalObjects: {}
-  serializedVersion: 2
-  frameRange: 0
-  startFrame: -1
-  endFrame: -1
-  colorSpace: 0
-  deinterlace: 0
-  encodeAlpha: 0
-  flipVertical: 0
-  flipHorizontal: 0
-  importAudio: 1
-  targetSettings: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
The previous splash video had no audio. I have added some audio effects like electric static noise and bouncing ball sounds. Please let me know if (and most importantly why) you disagree with the added audio, that would be great feedback as well.

You can also check the video with audio here: https://www.youtube.com/watch?v=_DB_wMDYOJY

## tl;dr
* Use new splash video (with audio)
* Add a (configurable) delay (white screen) of 2 seconds after the video has ended before main menu is shown.